### PR TITLE
Add the possibility to show the dialog also for visitors outside the EU

### DIFF
--- a/cookie-consent-polymer.html
+++ b/cookie-consent-polymer.html
@@ -131,6 +131,10 @@ Example:
         type: Boolean,
         value: false
       },
+      skipLocationCheck: {
+        type: Boolean,
+        value: false
+      },
       scrollConsent: {
         type: Boolean,
         value: false
@@ -226,7 +230,11 @@ Example:
 
     attached: function() {
       if (!this._cookieExists()) {
-        this.$.check_country.generateRequest();
+        if (this.skipLocationCheck) {
+          this._setup();
+        } else {
+          this.$.check_country.generateRequest();
+        }
       }
     }
 


### PR DESCRIPTION
This can be useful for performance purposes when the owner of the website knows the majority of its traffic comes from the EU: on a slow network, the request to freegeoip can take long to execute, and in the meanwhile the user can't view the dialog.
